### PR TITLE
fixes #12 on @katyhuff's computer.

### DIFF
--- a/cmake/FindCyclus.cmake
+++ b/cmake/FindCyclus.cmake
@@ -40,10 +40,16 @@ FIND_PATH(CYCLUS_CORE_TEST_INCLUDE_DIR agent_tests.h
   /usr/local/cyclus /opt/local/cyclus  
   PATH_SUFFIXES cyclus/include include include/cyclus include/cyclus/tests cyclus/include/tests)
 
-SET(
-  CYCLUS_CORE_TEST_INCLUDE_DIR ${CYCLUS_CORE_TEST_INCLUDE_DIR}
-  ${CYCLUS_CORE_TEST_INCLUDE_DIR}/../gtest
-  )
+# find the directory containing gtest
+FIND_PATH(CYCLUS_GTEST_INCLUDE_DIR gtest/gtest.h
+  HINTS "${CYCLUS_ROOT_DIR}" "${CYCLUS_ROOT_DIR}"
+  "${CYCLUS_ROOT_DIR}/include"
+  "${CYCLUS_ROOT_DIR}/include/cyclus"
+  /usr/local/cyclus /opt/local/cyclus
+  PATH_SUFFIXES cyclus/include include include/cyclus)
+
+SET(CYCLUS_CORE_TEST_INCLUDE_DIR ${CYCLUS_CORE_TEST_INCLUDE_DIR}
+  ${CYCLUS_GTEST_INCLUDE_DIR})
 
 # Add the root dir to the hints
 SET(CYCLUS_ROOT_DIR "${CYCLUS_CORE_INCLUDE_DIR}/../..")


### PR DESCRIPTION
This fixes #12 for me. Inspired by intrepid attempts of @gidden, this fix just uses find_path and seeks something _above_ the gtest folder, so that #include <gtest/gtest.h> will work. Including the gtest folder didn't work because gtest/gtest.h isn't in it... you know... 
